### PR TITLE
Add missing dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = [
     "docopt",
     "libcst",
     "black",
+    "MonkeyType",
+    "numpy",
+    "pandas",
+    "scipy",
+    "lark",
 ]
 classifiers = ["Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hey @gramster, thank you for making this tool available. I had to add a few packages to the `pyproject.toml` to get it to install from current `main` with `flit install` (and also with `pip install .`).

For context on why I'm trying out this tool: At scikit-image we are currently looking for a solution to add and maintain stubs and want to take the type descriptions in our docstrings into account. Long-term we'd like to have one source of truth, so generating stubs from docstrings seem like a natural approach. However, up until now I've had trouble getting docs2stubs to run. I'll open a separate issue for it.
